### PR TITLE
Add support for control panning for multiple audio sessions separately

### DIFF
--- a/CoreAudio/ChannelAudioVolume.cs
+++ b/CoreAudio/ChannelAudioVolume.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using CoreAudio.Interfaces;
+using NAudio.CoreAudioApi;
+
+namespace CoreAudio
+{
+    public class ChannelAudioVolume
+    {
+        private readonly IChannelAudioVolume realInterface;
+
+        public ChannelAudioVolume(AudioSessionControl session)
+        {
+            object rawAudioSessionControl = typeof(AudioSessionControl)
+                .GetField("audioSessionControlInterface", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(session);
+            if (rawAudioSessionControl is IChannelAudioVolume realInterface)
+            {
+                this.realInterface = realInterface;
+            }
+            else
+            {
+                throw new ArgumentException("parameter is not IChannelAudioVolume");
+            }
+        }
+
+        public int ChannelCount
+        {
+            get
+            {
+                Marshal.ThrowExceptionForHR(realInterface.GetChannelCount(out int count));
+                return count;
+            }
+        }
+
+        public float GetChannelVolume(int index)
+        {
+            Marshal.ThrowExceptionForHR(realInterface.GetChannelVolume(index, out float level));
+            return level;
+        }
+
+        public float SetChannelVolume(int index, float level)
+        {
+            Marshal.ThrowExceptionForHR(realInterface.SetChannelVolume(index, level, Guid.Empty));
+            return level;
+        }
+    }
+}

--- a/CoreAudio/Interfaces/IChannelAudioVolume.cs
+++ b/CoreAudio/Interfaces/IChannelAudioVolume.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace CoreAudio.Interfaces
+{
+    /// <summary>
+    /// Windows CoreAudio IChannelAudioVolume interface
+    /// Defined in AudioClient.h
+    /// </summary>
+    [Guid("1C158861-B533-4B30-B1CF-E853E51C59B8")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComImport]
+    internal interface IChannelAudioVolume
+    {
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        int GetChannelCount(out int count);
+
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        int SetChannelVolume([In] int index, [MarshalAs(UnmanagedType.R4), In] float level,
+            [MarshalAs(UnmanagedType.LPStruct), In] Guid eventContext);
+
+        [MethodImpl(MethodImplOptions.PreserveSig)]
+        int GetChannelVolume([In] int index, [MarshalAs(UnmanagedType.R4)] out float level);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ It checks for window positions every 500ms and always updates the position. It d
 # How to use
 Download the installer from the releases, install, then run WinPan whenever you like to move around your sound-playing-window. Terminate it with CTRL-C, and upon exiting it will restore center balance. That's it - not much more to it.
 
-Not much to this. It looks for windows with active audio sessions. If only one is found, it sets the left/right balance of the system audio relative to the horizontal position of that window on your screen(s). Supports multiple screens, but does not take into account pixel density (it assumes that screens and pixel density are roughly corresponding to your screen positions).
+Not much to this. It looks for windows with active audio sessions. If one is found, it sets the left/right balance of the system audio relative to the horizontal position of that window on your screen(s). Supports multiple screens, but does not take into account pixel density (it assumes that screens and pixel density are roughly corresponding to your screen positions).
 
 # Limitations
-Stero only (e.g. only channels 1 and 2 of your default audio interface are affected). The reason this is just active when only one window has an audio session, is that the Windows API does not allow you to control the stereo/multiple channel of a particular program, just its overall volume. So it seems right now there is no chance of panning multiple audio streams around separately. And moving them all to a side seemed - very messy. 
+Stero only (e.g. only channels 1 and 2 of your default audio interface are affected).
 
 Maybe at some I'll make it configurable, or even build a little UI, but for now this is it.


### PR DESCRIPTION
It seems we can get an `IChannelAudioVolume` from the audio session object `IAudioSessionControl`, which could be used to change the volume of each channel for individual sessions. Not documented anywhere, but works for me.